### PR TITLE
fix for wrong paginator links in blog

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -41,13 +41,13 @@ layout: base
     <section class="pagination" style="text-align:center">
       {% if paginator.previous_page %}
         {% if paginator.previous_page == 1 %}
-        <a href="/" class="btn btn-outline">‹ Newer</a>
+        <a href="/blog" class="btn btn-outline">‹ Newer</a>
         {% else %}
-        <a href="/page{{ paginator.previous_page }}" class="btn btn-outline">‹ Newer</a>
+        <a href="/blog/page{{ paginator.previous_page }}" class="btn btn-outline">‹ Newer</a>
         {% endif %}
       {% endif %}
       {% if paginator.next_page %}
-        <a href="/page{{ paginator.next_page }}" class="btn btn-outline">Older ›</a>
+        <a href="/blog/page{{ paginator.next_page }}" class="btn btn-outline">Older ›</a>
       {% endif %}
     </section>
 </article>


### PR DESCRIPTION
The pagination links at the bottom of your blog page do not work. I fixed them :)

Also I seem to be the only one reading your old blog entries...